### PR TITLE
Disable SSL and HTTPS requirements in the production environment

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -18,7 +18,7 @@ servers:
 #
 # Note: If using Cloudflare, set encryption mode in SSL/TLS setting to "Full" to enable CF-to-app encryption.
 proxy:
-  ssl: true
+  ssl: false
   host: app.example.com
 
 # Credentials for your image host.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,10 +25,10 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
-  config.assume_ssl = true
+  config.assume_ssl = false
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  config.force_ssl = false
 
   # Skip http-to-https redirect for the default health check endpoint.
   # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }


### PR DESCRIPTION
Turns out SSL certificates (even the free ones) need a domain, so I just disabled HTTPS in prod. The app will just use HTTP only. Closes #67.